### PR TITLE
#159965272 Add pagination to articles displayed

### DIFF
--- a/src/__tests__/jest/actions/fetchArticles.test.js
+++ b/src/__tests__/jest/actions/fetchArticles.test.js
@@ -11,7 +11,7 @@ import {
 import articlesMockData from "../../mock/articles";
 import config from "../../../config";
 
-const articles = articlesMockData.Articles.results;
+const articles = articlesMockData.Articles;
 const middleware = [thunk];
 const mockStore = configureMockStore(middleware);
 let store;

--- a/src/__tests__/jest/components/allArticles.test.jsx
+++ b/src/__tests__/jest/components/allArticles.test.jsx
@@ -14,7 +14,7 @@ const mockStore = configureStore(middleware);
 const store = mockStore({});
 
 const props = {
-  articles: [],
+  articles: {},
   fetching: true,
   fetchArticles: jest.fn()
 };
@@ -26,9 +26,8 @@ describe("Renders <Articles /> correctly", () => {
     </Provider>
   );
 
-  it("renders row when articles is not empty", () => {
-    wrapper.setProps({ article: articlesMockData.Articles.results });
-
-    expect(wrapper.find(".row").exists()).toBe(true);
+  it("renders Articles when articles is not empty", () => {
+    wrapper.setProps({ article: articlesMockData.Articles });
+    expect(wrapper.find("Articles").exists()).toBe(true);
   });
 });

--- a/src/__tests__/jest/components/myArticles.test.jsx
+++ b/src/__tests__/jest/components/myArticles.test.jsx
@@ -13,7 +13,7 @@ const mockStore = configureStore(middleware);
 const store = mockStore({});
 
 const props = {
-  articles: []
+  articles: {}
 };
 
 describe("Renders <Articles /> correctly", () => {
@@ -24,7 +24,7 @@ describe("Renders <Articles /> correctly", () => {
   });
 
   it("renders <Articles/> when articles is not empty", () => {
-    wrapper.setProps({ articles: articlesMockData.Articles.results });
+    wrapper.setProps({ articles: articlesMockData.Articles });
     expect(wrapper.find("Articles").exists()).toBe(true);
   });
 });

--- a/src/components/articles/Articles.jsx
+++ b/src/components/articles/Articles.jsx
@@ -1,50 +1,140 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import PropTypes from "prop-types";
-
 import { fetchArticles } from "../../redux/actions/fetchArticles";
 import ArticleCard from "../../views/Article/index";
+import config from "../../config";
+
+const url = `${config.BASE_URL}/articles/`;
 
 class Articles extends Component {
+  state = {
+    currentPage: 1
+  };
+
   componentDidMount() {
     const { fetch } = this.props;
     fetch();
   }
 
+  handlePageChange(paginationUrl, page, e) {
+    const { fetch } = this.props;
+    let { currentPage } = this.state;
+
+    let localPaginationUrl = paginationUrl;
+    if (e) {
+      if (e.target.id === "paginationNext") {
+        this.setState({ currentPage: (currentPage += 1) });
+      }
+      if (e.target.id === "paginationPrevious") {
+        this.setState({ currentPage: (currentPage -= 1) });
+      }
+    }
+    if (page) {
+      this.setState({
+        currentPage: page
+      });
+      localPaginationUrl = `${url}?page=${page}`;
+      fetch(null, localPaginationUrl);
+    } else {
+      fetch(null, localPaginationUrl);
+    }
+  }
+
+  renderPaginationButtons() {
+    const { articles } = this.props;
+    const { currentPage } = this.state;
+    const pageButtons = [];
+
+    for (
+      let pageNumber = 1;
+      pageNumber <= Math.ceil(articles.count / 20);
+      pageNumber += 1
+    ) {
+      pageButtons.push(
+        <button
+          id={pageNumber}
+          className={
+            currentPage === pageNumber
+              ? "btn btn-light active"
+              : "btn btn-light"
+          }
+          key={pageNumber}
+          type="button"
+          onClick={() => this.handlePageChange(null, pageNumber)}
+        >
+          {pageNumber}
+        </button>
+      );
+    }
+
+    return (
+      <div className="ah-pagination-buttons d-flex justify-content-center m-4">
+        <div className="btn-group" role="group">
+          <button
+            id="paginationPrevious"
+            className={
+              articles.previous ? "btn btn-light" : "btn btn-light disabled"
+            }
+            type="button"
+            onClick={e => this.handlePageChange(articles.previous, null, e)}
+          >
+            Previous
+          </button>
+          {pageButtons}
+          <button
+            id="paginationNext"
+            className={
+              articles.next ? "btn btn-light" : "btn btn-light disabled"
+            }
+            type="button"
+            onClick={e => this.handlePageChange(articles.next, null, e)}
+          >
+            Next
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   render() {
     const { articles } = this.props;
+
     return (
       <div className="container">
-        <div className="row">
-          {articles.map(article => (
-            <ArticleCard
-              slug={article.slug}
-              key={article.slug}
-              title={article.title}
-              description={article.description}
-              author={article.author}
-              timeToRead={article.time_to_read}
-              publishedAt={article.published_at}
-            />
-          ))}
-        </div>
+        {articles.results && (
+          <div className="row">
+            {articles.results.map(article => (
+              <ArticleCard
+                slug={article.slug}
+                key={article.slug}
+                title={article.title}
+                description={article.description}
+                author={article.author}
+                timeToRead={article.time_to_read}
+                publishedAt={article.published_at}
+              />
+            ))}
+          </div>
+        )}
+        {articles.results && this.renderPaginationButtons()}
       </div>
     );
   }
 }
 
 Articles.propTypes = {
-  articles: PropTypes.arrayOf(PropTypes.object),
+  articles: PropTypes.shape(),
   fetch: PropTypes.func.isRequired
 };
 
 Articles.defaultProps = {
-  articles: []
+  articles: () => {}
 };
 
 const mapStateToProps = ({ allArticlesReducer }) => {
   const { articles } = allArticlesReducer || {
-    articles: []
+    articles: {}
   };
   return {
     articles

--- a/src/components/articles/MyArticles.jsx
+++ b/src/components/articles/MyArticles.jsx
@@ -37,23 +37,27 @@ class Articles extends Component {
     return (
       <div className="container">
         <div className="ah-page-title pt-4 pb-4">Your Stories</div>
-        {articles.map(article => (
-          <FlatArticle
-            slug={article.slug}
-            key={article.slug}
-            title={article.title}
-            description={article.description}
-            publishedAt={article.published_at}
-            handleDelete={() => this.handleDelete(article.slug)}
-          />
-        ))}
+        {articles.results && (
+          <div>
+            {articles.results.map(article => (
+              <FlatArticle
+                slug={article.slug}
+                key={article.slug}
+                title={article.title}
+                description={article.description}
+                publishedAt={article.published_at}
+                handleDelete={() => this.handleDelete(article.slug)}
+              />
+            ))}
+          </div>
+        )}
       </div>
     );
   }
 }
 
 Articles.propTypes = {
-  articles: PropTypes.arrayOf(PropTypes.object),
+  articles: PropTypes.shape,
   fetch: PropTypes.func.isRequired,
   trash: PropTypes.func.isRequired,
   reset: PropTypes.func.isRequired,
@@ -61,12 +65,12 @@ Articles.propTypes = {
 };
 
 Articles.defaultProps = {
-  articles: []
+  articles: () => {}
 };
 
 const mapStateToProps = ({ deleteArticleReducer, allArticlesReducer }) => {
   const { articles } = allArticlesReducer || {
-    articles: []
+    articles: {}
   };
   const { success } = deleteArticleReducer || { success: false };
   return {

--- a/src/redux/actions/fetchArticles.js
+++ b/src/redux/actions/fetchArticles.js
@@ -3,7 +3,7 @@ import { ARTICLE_FETCH_SUCCESS, ARTICLE_FETCH_ERROR } from "../action_types";
 import { startFetch } from "./common";
 import config from "../../config";
 
-const url = `${config.BASE_URL}/articles/`;
+let url = `${config.BASE_URL}/articles/`;
 
 /**
  * Article fetch success
@@ -27,18 +27,31 @@ export const articleFetchError = error => ({
   error
 });
 
-export const fetchArticles = (username = null) => async dispatch => {
+export const fetchArticles = (
+  username = null,
+  paginationUrl = null
+) => async dispatch => {
   let response;
   dispatch(startFetch);
+
+  if (paginationUrl) {
+    url = paginationUrl;
+  }
   try {
     if (username) {
-      response = await axios.get(
-        `${url}?author__username__icontains=${username}`
-      );
+      if (paginationUrl) {
+        response = await axios.get(
+          `${paginationUrl}&&author__username__icontains=${username}`
+        );
+      } else {
+        response = await axios.get(
+          `${url}?author__username__icontains=${username}`
+        );
+      }
     } else {
       response = await axios.get(url);
     }
-    dispatch(articleFetchSuccess(response.data.Articles.results));
+    dispatch(articleFetchSuccess(response.data.Articles));
   } catch (error) {
     dispatch(articleFetchError(error.message));
   }

--- a/src/redux/reducers/initialState.js
+++ b/src/redux/reducers/initialState.js
@@ -25,7 +25,7 @@ const initialState = {
   isLogged: false,
   loading: false,
   allArticles: {
-    articles: [],
+    articles: {},
     error: {},
     fetching: false,
     fetched: false,

--- a/src/views/App/App.scss
+++ b/src/views/App/App.scss
@@ -637,7 +637,9 @@ h1 {
 }
 
 .ah-header-container {
-  width: 90%;
+  width: 90% !important;
+  flex-wrap: wrap;
+  align-items: center;
 }
 
 .ahStarRating {
@@ -667,4 +669,8 @@ h1 {
 
 .ah-badge-light {
   background-color: $bg-color !important;
+}
+
+.disabled {
+  pointer-events: none !important;
 }

--- a/src/views/Article/index.jsx
+++ b/src/views/Article/index.jsx
@@ -23,7 +23,7 @@ const ArticleCard = ({
         height="250"
       />
       <div className="card-body d-flex flex-column">
-        <h5 className="card-title">
+        <h5 className="card-title text-truncate">
           <a href={`articles/${slug}`}>{title}</a>
         </h5>
         <p className="card-text">{description}</p>

--- a/src/views/Header/index.jsx
+++ b/src/views/Header/index.jsx
@@ -97,30 +97,30 @@ class AHHeader extends Component {
       </nav>
     ) : (
       <div>
-        <nav className="navbar navbar-expand-lg navbar-light p-0">
-          <div className="container">
+        <nav className="ah-navbar navbar navbar-expand-lg navbar-light mb-4">
+          <div className="ah-header-container  d-flex justify-content-between mr-auto ml-auto">
             <Router>
               <a href="/" className="navbar-brand font-weight-bold">
                 Authors&apos; Haven
               </a>
             </Router>
-            <div
-              className="btn-toolbar"
-              role="toolbar"
-              aria-label="Toolbar with button groups"
+            <button
+              className="navbar-toggler"
+              type="button"
+              data-toggle="collapse"
+              data-target="#navbarTogglerDemo03"
+              aria-controls="navbarTogglerDemo03"
+              aria-expanded="false"
+              aria-label="Toggle navigation"
             >
-              <div
-                className="btn-group mr-2"
-                role="group"
-                aria-label="Second group"
-              >
-                <div
-                  className="btn-group"
-                  role="group"
-                  aria-label="Third group"
-                >
+              <span className="navbar-toggler-icon" />
+            </button>
+            <div className="collapse navbar-collapse" id="navbarTogglerDemo03">
+              <ul className="navbar-nav ml-auto mt-2 mt-lg-0">
+                <li className="nav-item active">
                   <AuthButton isAuthenticated={false} />
-
+                </li>
+                <li className="nav-item">
                   <Button
                     className="btn btn-outline-success rounded"
                     type="button"
@@ -128,21 +128,16 @@ class AHHeader extends Component {
                     dataToggle="modal"
                     label="Get Started"
                   />
-                  <Button
-                    id="newPassword"
-                    className="d-none"
-                    type="button"
-                    dataTarget="#ahNewPasswordModal"
-                    dataToggle="modal"
-                    label="Reset password"
-                  />
-                  <div
-                    className="btn-group mr-2"
-                    role="group"
-                    aria-label="Second group"
-                  />
-                </div>
-              </div>
+                </li>
+                <Button
+                  id="newPassword"
+                  className="d-none"
+                  type="button"
+                  dataTarget="#ahNewPasswordModal"
+                  dataToggle="modal"
+                  label="Reset password"
+                />
+              </ul>
             </div>
           </div>
         </nav>


### PR DESCRIPTION
#### What does this PR do?
- Adds pagination to articles displayed for easier traversal

#### Description of tasks to be completed
- Create a component to display consecutive numbers for displaying page numbers.
- Retrieve articles based on the page number clicked by users
- Mark the page number clicked to be active

#### How should this be manually tested?
$ git clone https://github.com/andela/mag-ah-frontend.git
$ git checkout ft-paginate-articles-159965272
$ cd mag-ah-frontend
$ cp .env_sample .env
$ npm install
$ npm start
- Navigate to http://localhost:3000
- Scroll down and locate the page numbers below the articles
- Click any page number and observe what happens; **the articles loaded should be for the page number you have clicked**.
- Experiment with the buttons labeled **Previous** and **Next** too

#### Any background context you want to provide?
Good choices about data paging are an important part of design and development. Sometimes we need to get lists of data from the server, and sometimes these lists can be really long. Breaking lists up into smaller, discreet "pages" can reduce server overhead and improve response time.
Pagination helps one to load limited records and provide a way for users to view more data from the application. 

#### What are the relevant pivotal tracker stories?
[Pagination support for articles](https://www.pivotaltracker.com/story/show/159965272)

#### Screenshots (if appropriate)
<img width="1698" alt="screen shot 2018-10-31 at 18 20 31" src="https://user-images.githubusercontent.com/20840601/47798579-bf783280-dd39-11e8-9302-2349b4e89861.png">

